### PR TITLE
Avoid duplicate publisher elements in OAI-ETDMS

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_etdms.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_etdms.xsl
@@ -71,9 +71,6 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
 				<coverage><xsl:value-of select="." /></coverage>
 			</xsl:for-each>
-			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
-				<publisher><xsl:value-of select="." /></publisher>
-			</xsl:for-each>
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
 				<publisher><xsl:value-of select="." /></publisher>
 			</xsl:for-each>


### PR DESCRIPTION
It was possible to have duplicate publisher elements in the OAI-ETDMS
output if the record had been described using both dc.publisher and
dc.publisher.grantor.

Every thesis should have a dc.publisher.grantor field in our repository,
so let's rely on that.

10219/2193 is an example that had both
10219/2888 is an example that has only dc.publisher.grantor

Signed-off-by: Dan Scott <dscott@laurentian.ca>